### PR TITLE
V1.2.3 

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX = "The schedule index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_SCHEDULESS_LISTED_OVERVIEW = "%1$d schedules listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddScheduleCommand.java
@@ -61,7 +61,7 @@ public class AddScheduleCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddCommand // instanceof handles nulls
+                || (other instanceof AddScheduleCommand // instanceof handles nulls
                 && toAddSchedule.equals(((AddScheduleCommand) other).toAddSchedule));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteScheduleCommand.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.schedule.Schedule;
+
+/**
+ * Deletes a schedule identified using it's displayed index from the schedule list.
+ */
+public class DeleteScheduleCommand extends Command {
+    public static final String COMMAND_WORD = "deleteSchedule";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the schedule identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_SCHEDULE_SUCCESS = "Deleted Schedule: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteScheduleCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Schedule> lastShownList = model.getFilteredScheduleList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SCHEDULE_DISPLAYED_INDEX);
+        }
+
+        Schedule scheduleToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteSchedule(scheduleToDelete);
+        model.commitAddressBook();
+        return new CommandResult(String.format(MESSAGE_DELETE_SCHEDULE_SUCCESS, scheduleToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteScheduleCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteScheduleCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SCHEDULES;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
@@ -13,13 +14,14 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all persons and schedules.";
 
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredScheduleList(PREDICATE_SHOW_ALL_SCHEDULES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.AddScheduleCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteScheduleCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -63,6 +64,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteScheduleCommand.COMMAND_WORD:
+            return new DeleteScheduleCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/DeleteScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteScheduleCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteScheduleCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class DeleteScheduleCommandParser implements Parser<DeleteScheduleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns an DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteScheduleCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteScheduleCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteScheduleCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -83,8 +83,8 @@ public class ParserUtil {
     public static Type parseStatus(String status) throws ParseException {
         requireNonNull(status);
         String trimmedStatus = status.trim();
-        if (!Name.isValidName(trimmedStatus)) {
-            throw new ParseException(Name.MESSAGE_NAME_CONSTRAINTS);
+        if (!Type.isValidType(trimmedStatus)) {
+            throw new ParseException(Type.MESSAGE_TYPE_CONSTRAINTS);
         }
         return new Type(trimmedStatus);
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -152,7 +152,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public void deleteSchedule(Schedule target) {
-        versionedScheduleList.removePerson(target);
+        versionedScheduleList.removeSchedule(target);
         indicateScheduleListChanged();
     }
 

--- a/src/main/java/seedu/address/model/schedule/Date.java
+++ b/src/main/java/seedu/address/model/schedule/Date.java
@@ -13,7 +13,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #Date(String)}
  */
 public class Date {
-    public static final String DATE_VALIDATION_REGEX = "(0?[1-9]|[12][0-9]|3[01])/(0?[1-9]|1[012])/((20)\\d\\d)";
+    public static final String DATE_VALIDATION_REGEX = "(0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/((20)\\d\\d)";
 
     public static final String MESSAGE_DATE_CONSTRAINTS_DEFAULT =
             "Date should only be in the format of DD/MM/YYYY, it should not be blank and within "

--- a/src/main/java/seedu/address/model/schedule/NricScheduleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/schedule/NricScheduleContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.schedule;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Schedule}'s {@code Name} matches any of the Id given.
+ */
+public class NricScheduleContainsKeywordsPredicate implements Predicate <Schedule> {
+    private final List<String> keywords;
+
+    public NricScheduleContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Schedule schedule) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(schedule.getEmployeeId().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof NricScheduleContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((NricScheduleContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/schedule/ScheduleList.java
+++ b/src/main/java/seedu/address/model/schedule/ScheduleList.java
@@ -87,7 +87,7 @@ public class ScheduleList implements ReadOnlyScheduleList {
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */
-    public void removePerson(Schedule key) {
+    public void removeSchedule(Schedule key) {
         schedules.remove(key);
     }
 

--- a/src/main/java/seedu/address/model/schedule/Type.java
+++ b/src/main/java/seedu/address/model/schedule/Type.java
@@ -9,13 +9,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Type {
 
     public static final String MESSAGE_TYPE_CONSTRAINTS =
-            "TYPE should only contain alphanumeric characters and spaces, and it should not be blank";
+            "TYPE should only be WORK or LEAVE, case not sensitive and it should not be blank";
 
     /*
-     * The first character of the Type must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Type must either be WORK or LEAVE, exact match.
      */
-    public static final String TYPE_VALIDATION_REGEX = "(^WORK$|^LEAVE$)";
+    public static final String TYPE_VALIDATION_REGEX = "(^LEAVE$)|(^WORK$)";
 
 
     public final String value;

--- a/src/main/java/seedu/address/storage/schedule/XmlSerializableScheduleList.java
+++ b/src/main/java/seedu/address/storage/schedule/XmlSerializableScheduleList.java
@@ -19,7 +19,7 @@ import seedu.address.model.schedule.ScheduleList;
 @XmlRootElement(name = "schedulelist")
 public class XmlSerializableScheduleList {
 
-    public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_SCHEDULE = "Schedules list contains duplicate schedule(s).";
 
     @XmlElement
     private List<XmlAdaptedSchedule> schedules;
@@ -51,7 +51,7 @@ public class XmlSerializableScheduleList {
         for (XmlAdaptedSchedule p : schedules) {
             Schedule schedule = p.toModelType();
             if (scheduleList.hasSchedule(schedule)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+                throw new IllegalValueException(MESSAGE_DUPLICATE_SCHEDULE);
             }
             scheduleList.addSchedule(schedule);
         }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,6 +11,11 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.Accordion?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.Tab?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          minWidth="1040" minHeight="600" onCloseRequest="#handleExit">
   <icons>
@@ -51,13 +56,40 @@
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
-            <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            <TabPane fx:id="tabPane" VBox.vgrow="ALWAYS" tabClosingPolicy="UNAVAILABLE">
+                <tabs>
+                    <Tab fx:id="addressBookTab" text="Employees">
+                        <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                    </Tab>
+                    <Tab fx:id="anncounementTab" text="Announcements">
+                        <StackPane fx:id="anncounementListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                    </Tab>
+                </tabs>
+            </TabPane>
           </VBox>
           <VBox fx:id="scheduleList" minWidth="340" prefWidth="340" SplitPane.resizableWithParent="false">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
-            <StackPane fx:id="scheduleListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                <Accordion>
+                  <panes>
+                      <TitledPane animated="True" text= "Schedules">
+                          <content>
+                              <StackPane fx:id="scheduleListPanelPlaceholder" VBox.vgrow="ALWAYS" styleClass="background"/>
+                          </content>
+                      </TitledPane>
+                      <TitledPane animated="True" text="Expenses">
+                          <content>
+                              <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                          </content>
+                      </TitledPane>
+                      <TitledPane animated="false" text="Salary">
+                          <content>
+                              <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                          </content>
+                      </TitledPane>
+                  </panes>
+              </Accordion>
           </VBox>
           <StackPane fx:id="browserPlaceholder" prefWidth="340" >
             <padding>

--- a/src/test/data/XmlScheduleListStorageTest/NotXmlFormatScheduleList.xml
+++ b/src/test/data/XmlScheduleListStorageTest/NotXmlFormatScheduleList.xml
@@ -1,0 +1,1 @@
+not xml format!

--- a/src/test/data/XmlScheduleListStorageTest/invalidAndValidScheduleScheduleList.xml
+++ b/src/test/data/XmlScheduleListStorageTest/invalidAndValidScheduleScheduleList.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addressbook>
+    <!-- Valid Schedule -->
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>WORK</type>
+        <date>01/01/2019</date>
+    </schedules>
+    <!-- Schedule with invalid date field -->
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>WORK</type>
+        <date>01/13/2019</date>
+    </schedules>
+</addressbook>

--- a/src/test/data/XmlScheduleListStorageTest/invalidScheduleScheduleList.xml
+++ b/src/test/data/XmlScheduleListStorageTest/invalidScheduleScheduleList.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<schedulelist>
+    <!-- Schedule with invalid date field -->
+    <schedules>
+        <employeeId  isPrivate="false">000001</employeeId>
+        <type  isPrivate="false">LEAVE</type>
+        <date  isPrivate="false">02/13/2018</date>
+    </schedules>
+</schedulelist>

--- a/src/test/data/XmlSerializableScheduleListTest/duplicateScheduleScheduleList.xml
+++ b/src/test/data/XmlSerializableScheduleListTest/duplicateScheduleScheduleList.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<schedulelist>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>LEAVE</type>
+        <date>02/02/2018</date>
+    </schedules>
+    <!-- Schedule with same schedule -->
+	<schedules>
+        <employeeId>000001</employeeId>
+        <type>LEAVE</type>
+        <date>02/02/2018</date>
+    </schedules>
+</schedulelist>

--- a/src/test/data/XmlSerializableScheduleListTest/invalidScheduleScheduleList.xml
+++ b/src/test/data/XmlSerializableScheduleListTest/invalidScheduleScheduleList.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<schedulelist>
+    <!-- Schedule with invalid date field -->
+    <schedules>
+        <employeeId  isPrivate="false">000001</employeeId>
+        <type  isPrivate="false">LEAVE</type>
+        <date  isPrivate="false">02/13/2018</date>
+    </schedules>
+</schedulelist>

--- a/src/test/data/XmlSerializableScheduleListTest/typicalSchedulesScheduleList.xml
+++ b/src/test/data/XmlSerializableScheduleListTest/typicalSchedulesScheduleList.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<schedulelist>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>WORK</type>
+        <date>01/01/2019</date>
+    </schedules>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>WORK</type>
+        <date>10/10/2020</date>
+    </schedules>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>WORK</type>
+        <date>20/03/2099</date>
+    </schedules>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>LEAVE</type>
+        <date>04/04/2019</date>
+    </schedules>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>LEAVE</type>
+        <date>05/05/2019</date>
+    </schedules>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>LEAVE</type>
+        <date>06/06/2019</date>
+    </schedules>
+    <schedules>
+        <employeeId>000001</employeeId>
+        <type>LEAVE</type>
+        <date>07/07/2019</date>
+    </schedules>
+</schedulelist>

--- a/src/test/java/seedu/address/logic/commands/AddScheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddScheduleCommandTest.java
@@ -1,0 +1,325 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javafx.collections.ObservableList;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.addressbook.ReadOnlyAddressBook;
+import seedu.address.model.expenses.Expenses;
+import seedu.address.model.expenses.ReadOnlyExpensesList;
+import seedu.address.model.person.Person;
+import seedu.address.model.schedule.ReadOnlyScheduleList;
+import seedu.address.model.schedule.Schedule;
+import seedu.address.model.schedule.ScheduleList;
+import seedu.address.testutil.schedule.ScheduleBuilder;
+
+public class AddScheduleCommandTest {
+
+    private static final CommandHistory EMPTY_COMMAND_HISTORY = new CommandHistory();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+
+    @Test
+    public void constructor_nullSchedule_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new AddScheduleCommand(null);
+    }
+
+    @Test
+    public void execute_scheduleAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingScheduleAdded modelStub = new ModelStubAcceptingScheduleAdded();
+        Schedule validSchedule = new ScheduleBuilder().build();
+
+        CommandResult commandResult = new AddScheduleCommand(validSchedule).execute(modelStub, commandHistory);
+
+        assertEquals(String.format(AddScheduleCommand.MESSAGE_SUCCESS, validSchedule), commandResult.feedbackToUser);
+        assertEquals(Arrays.asList(validSchedule), modelStub.schedulesAdded);
+        assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
+    }
+
+    @Test
+    public void execute_duplicateSchedule_throwsCommandException() throws Exception {
+        Schedule validSchedule = new ScheduleBuilder().build();
+        AddScheduleCommand addScheduleCommand = new AddScheduleCommand(validSchedule);
+        ModelStub modelStub = new ModelStubWithSchedule(validSchedule);
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(AddScheduleCommand.MESSAGE_DUPLICATE_SCHEDULE);
+        addScheduleCommand.execute(modelStub, commandHistory);
+    }
+
+    @Test
+    public void equals() {
+        Schedule alice = new ScheduleBuilder().withEmployeeId("000001").withType("LEAVE").build();
+        Schedule bob = new ScheduleBuilder().withEmployeeId("000002").withType("WORK").build();
+        AddScheduleCommand addAliceCommand = new AddScheduleCommand(alice);
+        AddScheduleCommand addBobCommand = new AddScheduleCommand(bob);
+
+        // same object -> returns true
+        assertTrue(addAliceCommand.equals(addAliceCommand));
+
+        // same values -> returns true
+        AddScheduleCommand addAliceCommandCopy = new AddScheduleCommand(alice);
+        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAliceCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAliceCommand.equals(null));
+
+        // different schedule -> returns false
+        assertFalse(addAliceCommand.equals(addBobCommand));
+    }
+
+    /**
+     * A default model stub that have all of the methods failing.
+     */
+    private class ModelStub implements Model {
+
+        @Override
+        public void addExpenses(Expenses expenses) {
+            throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addSchedule(Schedule schedule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        //------------------------------------------------
+        @Override
+        public void resetAddressBookData(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void resetDataExpenses(ReadOnlyExpensesList newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void resetScheduleListData(ReadOnlyScheduleList newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public ReadOnlyExpensesList getExpensesList() {
+            throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyScheduleList getScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public boolean hasExpenses(Expenses expenses) {
+            throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasEmployeeId(Person person) {
+            return true;
+        }
+
+        @Override
+        public boolean hasSchedule(Schedule schedule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public void deleteExpenses(Expenses target) {
+            throw new AssertionError("This method should not be called."); }
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteSchedule(Schedule target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        //------------------------------------------------
+        @Override
+        public void updateExpenses(Expenses target, Expenses editedExpenses) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updatePerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateSchedule(Schedule target, Schedule editedSchedule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        //------------------------------------------------
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Schedule> getFilteredScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredScheduleList(Predicate<Schedule> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public boolean canUndoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canUndoScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public boolean canRedoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canRedoScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public void undoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        @Override
+        public void undoScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public void redoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void redoScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        //------------------------------------------------
+        @Override
+        public void commitAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void commitExpensesList() {
+            throw new AssertionError("This method should not be called."); }
+
+        @Override
+        public void commitScheduleList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+    }
+
+    /**
+     * A Model stub that contains a single schedule.
+     */
+    private class ModelStubWithSchedule extends ModelStub {
+        private final Schedule schedule;
+
+        ModelStubWithSchedule(Schedule schedule) {
+            requireNonNull(schedule);
+            this.schedule = schedule;
+        }
+
+        @Override
+        public boolean hasSchedule(Schedule schedule) {
+            requireNonNull(schedule);
+            return this.schedule.isSameSchedule(schedule);
+        }
+    }
+
+    /**
+     * A Model stub that always accept the person being added.
+     */
+    private class ModelStubAcceptingScheduleAdded extends ModelStub {
+        final ArrayList<Schedule> schedulesAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasSchedule(Schedule schedule) {
+            requireNonNull(schedule);
+            return schedulesAdded.stream().anyMatch(schedule::isSameSchedule);
+        }
+
+        @Override
+        public void addSchedule(Schedule schedule) {
+            requireNonNull(schedule);
+            schedulesAdded.add(schedule);
+        }
+
+        @Override
+        public void commitScheduleList() {
+            // called by {@code AddCommand#execute()}
+        }
+
+        @Override
+        public ReadOnlyScheduleList getScheduleList() {
+            return new ScheduleList();
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/schedule/TypeTest.java
+++ b/src/test/java/seedu/address/model/schedule/TypeTest.java
@@ -29,8 +29,9 @@ public class TypeTest {
         // invalid type
         assertFalse(Type.isValidType("")); // empty string
         assertFalse(Type.isValidType(" ")); // spaces only
-        assertFalse(Type.isValidType("W69K")); // middle chars no match
-        assertFalse(Type.isValidType("W69K")); // middle chars no match
+        assertFalse(Type.isValidType("W69K")); // middle chars wrong no match
+        assertFalse(Type.isValidType("okWORK")); // extra chars in front no match
+        assertFalse(Type.isValidType("WORKok")); // extra chars behind no match
 
         // valid type
         assertTrue(Type.isValidType("WORK"));

--- a/src/test/java/seedu/address/storage/XmlAdaptedScheduleTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedScheduleTest.java
@@ -1,0 +1,83 @@
+package seedu.address.storage;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.address.storage.schedule.XmlAdaptedSchedule.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.testutil.schedule.TypicalSchedules.BENSON_WORK;
+
+import org.junit.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.EmployeeId;
+import seedu.address.model.schedule.Date;
+import seedu.address.model.schedule.Type;
+import seedu.address.storage.schedule.XmlAdaptedSchedule;
+import seedu.address.testutil.Assert;
+
+public class XmlAdaptedScheduleTest {
+
+    private static final String INVALID_TYPE = "R@chel";
+    private static final String INVALID_DATE = "40/13/9999";
+    private static final String INVALID_EMPLOYEEID = " ";
+
+    private static final String VALID_EMPLOYEEID = BENSON_WORK.getEmployeeId().toString();
+    private static final String VALID_DATE = BENSON_WORK.getScheduleDate().toString();
+    private static final String VALID_TYPE = BENSON_WORK.getType().toString();
+
+    @Test
+    public void toModelType_validScheduleDetails_returnsSchedule() throws Exception {
+        XmlAdaptedSchedule schedule = new XmlAdaptedSchedule(BENSON_WORK);
+        assertEquals(BENSON_WORK, schedule.toModelType());
+    }
+
+    //-------------------------------------------//
+    @Test
+    public void toModelType_invalidType_throwsIllegalValueException() {
+        XmlAdaptedSchedule schedule =
+                new XmlAdaptedSchedule (VALID_EMPLOYEEID, INVALID_TYPE, VALID_DATE);
+        String expectedMessage = Type.MESSAGE_TYPE_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, schedule::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullType_throwsIllegalValueException() {
+        XmlAdaptedSchedule schedule =
+                new XmlAdaptedSchedule (VALID_EMPLOYEEID, null, VALID_DATE);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Type.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, schedule::toModelType);
+    }
+
+    //-------------------------------------------//
+    @Test
+    public void toModelType_invalidDate_throwsIllegalValueException() {
+        XmlAdaptedSchedule schedule =
+                new XmlAdaptedSchedule (VALID_EMPLOYEEID, VALID_TYPE, INVALID_DATE);
+        String expectedMessage = Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, schedule::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDate_throwsIllegalValueException() {
+        XmlAdaptedSchedule schedule =
+                new XmlAdaptedSchedule (VALID_EMPLOYEEID, VALID_TYPE, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, schedule::toModelType);
+    }
+
+    //-------------------------------------------//
+
+    @Test
+    public void toModelType_invalidEmployeeId_throwsIllegalValueException() {
+        XmlAdaptedSchedule schedule =
+                new XmlAdaptedSchedule(INVALID_EMPLOYEEID, VALID_TYPE, VALID_DATE);
+        String expectedMessage = EmployeeId.MESSAGE_EMPLOYEEID_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, schedule::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullEmployeeId_throwsIllegalValueException() {
+        XmlAdaptedSchedule schedule =
+                new XmlAdaptedSchedule(null, VALID_TYPE, VALID_DATE);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, EmployeeId.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, schedule::toModelType);
+    }
+}

--- a/src/test/java/seedu/address/storage/XmlScheduleListStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlScheduleListStorageTest.java
@@ -1,0 +1,127 @@
+package seedu.address.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static seedu.address.testutil.schedule.TypicalSchedules.ALICE_WORK;
+import static seedu.address.testutil.schedule.TypicalSchedules.AMY;
+import static seedu.address.testutil.schedule.TypicalSchedules.BOB;
+import static seedu.address.testutil.schedule.TypicalSchedules.getTypicalScheduleList;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.model.schedule.ReadOnlyScheduleList;
+import seedu.address.model.schedule.ScheduleList;
+import seedu.address.storage.schedule.XmlScheduleListStorage;
+
+public class XmlScheduleListStorageTest {
+
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlScheduleListStorageTest");
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void readScheduleList_nullFilePath_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
+        readScheduleList(null);
+    }
+
+    private java.util.Optional<ReadOnlyScheduleList> readScheduleList(String filePath) throws Exception {
+        return new XmlScheduleListStorage(Paths.get(filePath)).readScheduleList(addToTestDataPathIfNotNull(filePath));
+    }
+
+    private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
+        return prefsFileInTestDataFolder != null
+                ? TEST_DATA_FOLDER.resolve(prefsFileInTestDataFolder)
+                : null;
+    }
+
+    @Test
+    public void read_missingFile_emptyResult() throws Exception {
+        assertFalse(readScheduleList("NonExistentFile.xml").isPresent());
+    }
+
+    @Test
+    public void read_notXmlFormat_exceptionThrown() throws Exception {
+
+        thrown.expect(DataConversionException.class);
+        readScheduleList("NotXmlFormatScheduleList.xml");
+
+        /* IMPORTANT: Any code below an exception-throwing line (like the one above) will be ignored.
+         * That means you should not have more than one exception test in one method
+         */
+    }
+
+    @Test
+    public void readScheduleList_invalidScheduleScheduleList_throwDataConversionException() throws Exception {
+        thrown.expect(DataConversionException.class);
+        readScheduleList("invalidScheduleScheduleList.xml");
+    }
+
+    @Test
+    public void readScheduleList_invalidAndValidScheduleScheduleList_throwDataConversionException() throws Exception {
+        thrown.expect(DataConversionException.class);
+        readScheduleList("invalidAndValidScheduleScheduleList.xml");
+    }
+
+    @Test
+    public void readAndSaveScheduleList_allInOrder_success() throws Exception {
+        Path filePath = testFolder.getRoot().toPath().resolve("TempAddressBook.xml");
+        ScheduleList original = getTypicalScheduleList();
+        XmlScheduleListStorage xmlScheduleListStorage = new XmlScheduleListStorage(filePath);
+
+        //Save in new file and read back
+        xmlScheduleListStorage.saveScheduleList(original, filePath);
+        ReadOnlyScheduleList readBack = xmlScheduleListStorage.readScheduleList(filePath).get();
+        assertEquals(original, new ScheduleList(readBack));
+
+        //Modify data, overwrite exiting file, and read back
+        original.addSchedule(AMY);
+        original.removeSchedule(ALICE_WORK);
+        xmlScheduleListStorage.saveScheduleList(original, filePath);
+        readBack = xmlScheduleListStorage.readScheduleList(filePath).get();
+        assertEquals(original, new ScheduleList(readBack));
+
+        //Save and read without specifying file path
+        original.addSchedule(BOB);
+        xmlScheduleListStorage.saveScheduleList(original); //file path not specified
+        readBack = xmlScheduleListStorage.readScheduleList().get(); //file path not specified
+        assertEquals(original, new ScheduleList(readBack));
+    }
+
+    @Test
+    public void saveScheduleList_nullScheduleList_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        saveScheduleList(null, "SomeFile.xml");
+    }
+
+    /**
+     * Saves {@code addressBook} at the specified {@code filePath}.
+     */
+    private void saveScheduleList(ReadOnlyScheduleList scheduleList, String filePath) {
+        try {
+            new XmlScheduleListStorage(Paths.get(filePath))
+                    .saveScheduleList(scheduleList, addToTestDataPathIfNotNull(filePath));
+        } catch (IOException ioe) {
+            throw new AssertionError("There should not be an error writing to the file.", ioe);
+        }
+    }
+
+    @Test
+    public void saveScheduleList_nullFilePath_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        saveScheduleList(new ScheduleList(), null);
+    }
+
+}

--- a/src/test/java/seedu/address/storage/XmlSerializableScheduleListTest.java
+++ b/src/test/java/seedu/address/storage/XmlSerializableScheduleListTest.java
@@ -1,0 +1,53 @@
+package seedu.address.storage;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.XmlUtil;
+import seedu.address.model.schedule.ScheduleList;
+import seedu.address.storage.schedule.XmlSerializableScheduleList;
+import seedu.address.testutil.schedule.TypicalSchedules;
+
+
+public class XmlSerializableScheduleListTest {
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlSerializableScheduleListTest");
+    private static final Path TYPICAL_SCHEDULES_FILE = TEST_DATA_FOLDER.resolve("typicalSchedulesScheduleList.xml");
+    private static final Path INVALID_SCHEDULE_FILE = TEST_DATA_FOLDER.resolve("invalidScheduleScheduleList.xml");
+    private static final Path DUPLICATE_SCHEDULE_FILE = TEST_DATA_FOLDER.resolve("duplicateScheduleScheduleList.xml");
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void toModelType_typicalSchedulesFile_success() throws Exception {
+        XmlSerializableScheduleList dataFromFile = XmlUtil.getDataFromFile(TYPICAL_SCHEDULES_FILE,
+                XmlSerializableScheduleList.class);
+        ScheduleList scheduleListFromFile = dataFromFile.toModelType();
+        ScheduleList typicalSchedulesScheduleList = TypicalSchedules.getTypicalScheduleList();
+        assertEquals(scheduleListFromFile, typicalSchedulesScheduleList);
+    }
+
+    @Test
+    public void toModelType_invalidScheduleList_throwsIllegalValueException() throws Exception {
+        XmlSerializableScheduleList dataFromFile = XmlUtil.getDataFromFile(INVALID_SCHEDULE_FILE,
+                XmlSerializableScheduleList.class);
+        thrown.expect(IllegalValueException.class);
+        dataFromFile.toModelType();
+    }
+
+    @Test
+    public void toModelType_duplicatePersons_throwsIllegalValueException() throws Exception {
+        XmlSerializableScheduleList dataFromFile = XmlUtil.getDataFromFile(DUPLICATE_SCHEDULE_FILE,
+                XmlSerializableScheduleList.class);
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(XmlSerializableScheduleList.MESSAGE_DUPLICATE_SCHEDULE);
+        dataFromFile.toModelType();
+    }
+}

--- a/src/test/java/seedu/address/testutil/schedule/TypicalSchedules.java
+++ b/src/test/java/seedu/address/testutil/schedule/TypicalSchedules.java
@@ -32,7 +32,7 @@ public class TypicalSchedules {
             .withDate("07/07/2019").withType("LEAVE").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
-    public static final Schedule AMY = new ScheduleBuilder().withEmployeeId("000001")
+    public static final Schedule AMY = new ScheduleBuilder().withEmployeeId("000010")
             .withDate("01/01/2019").withType("WORK").build();
     public static final Schedule BOB = new ScheduleBuilder().withEmployeeId("000001")
             .withDate("01/01/2019").withType("WORK").build();


### PR DESCRIPTION
**Milestone 2** Resolves#66 issue.
**V1.2.3 Schedule Command** 
- Test case updated
-  **Enhanced command** `find`: Find by name keywords, filters person and schedule list.
-  **Enhanced command** `list`: Lists person and schedule list.
- **Enhanced command** `delete`: Delete by addressbook index, deletes person and associated schedule to the person.

**V1.2.2 Schedule Command**.
- Fixed Date and Type field bug
- Test case updated

**V1.2.1 Schedule Command**
- Schedule list user interface
- Check Employee Id exists, before allowing user to add a new schedule with the specified employee id.
- Enhanced Date model and Type model regular expression check.
- Test case updated
---
**Milestone 1** Resolves#66 issue.
**V1.1.3 Schedule Command**
- Add Schedule: Adds a new work or leave schedule for an employee, by date and employee id.
-  **New Command**`Schedule`: schedule id/[6digit] d/[DD/MM/YYYY] t/[WORK/LEAVE] 
- Storage: Stores schedule in ScheduleList.xml
---